### PR TITLE
Change to address breaking change to pg 8

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports.setDatabaseUrl = (url) => databaseUrl = url
 module.exports.getDatabaseUrl = () => databaseUrl
 
 const params = url.parse(databaseUrl);
-let ssl = ( PGSSLMODE === 'require' ),
+let ssl = ( PGSSLMODE === 'require' || PGSSLMODE === 'no-verify' ? { rejectUnauthorized: false } : false),
   auth = params.auth.split(':'),
   config = {
     user: auth[0],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-lequel",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Simple Database query abstraction library lescapes style",
   "main": "/lib/",
   "devDependencies": {


### PR DESCRIPTION
node-postgres 8.0 introduced a change:
`Change default behavior when not specifying rejectUnauthorized with the SSL connection parameters. Previously we defaulted to rejectUnauthorized: false when it was not specifically included. We now default to rejectUnauthorized: true. Manually specify { ssl: { rejectUnauthorized: false } } for old behavior.`
https://node-postgres.com/announcements#2020-02-25

This change is required to allow upgrade of reporting service dependencies https://github.com/lux-group/svc-reporting/pull/1147