### PR TITLE
remove unsupported no-verify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports.setDatabaseUrl = (url) => databaseUrl = url
 module.exports.getDatabaseUrl = () => databaseUrl
 
 const params = url.parse(databaseUrl);
-let ssl = ( PGSSLMODE === 'require' || PGSSLMODE === 'no-verify' ? { rejectUnauthorized: false } : false),
+let ssl = ( PGSSLMODE === 'require' ? { rejectUnauthorized: false } : false),
   auth = params.auth.split(':'),
   config = {
     user: auth[0],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-lequel",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Simple Database query abstraction library lescapes style",
   "main": "/lib/",
   "devDependencies": {


### PR DESCRIPTION
Using PGSSLMODE=no-verify helped in some cases but this led to issues with psql:
$ export PGSSLMODE=no-verify
$ psql
psql: error: invalid sslmode value: "no-verify"